### PR TITLE
Throw the actual error when connecting to redshift

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -9,7 +9,7 @@ var Redshift = function(config){
     pg.connect(config, function(err, client, done) {
       if(err) {
         done(client); //https://github.com/brianc/node-postgres/wiki/Example
-        throw new Error('error fetching client from pool', err);
+        throw err;
       }
       else {
         // store the client instance to make queries with


### PR DESCRIPTION
When connecting to the database, wrapping the original error make it lost the original reason.
