### PR TITLE
Added queryPromise method for users to utilize promises instead of callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ var redshiftClient = require('./redshift.js');
 // options is an optional object with one property so far {raw: true} returns 
 // just the data from redshift. {raw: false} returns the data with the pg object
 redshiftClient.query(queryString, [options], callback);
+
+// if you prefer promises to callbacks, you can use the queryPromise which returns a thenable.
+redshiftClient.queryPromise(queryString, [options]);
 ```
 
 ##### Raw connection(using {rawConnection: true})

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 module.exports = require('./lib/connection.js');
 module.exports.query = require('./lib/query.js');
+module.exports.queryPromise = require('./lib/queryPromise.js');
 module.exports.model = require('./lib/model.js');
 module.exports.import = require('./lib/model.js').import;

--- a/lib/queryPromise.js
+++ b/lib/queryPromise.js
@@ -2,7 +2,7 @@ var Redshift = require('./connection.js');
 
 Redshift.prototype.queryPromise = function (query, options) {
   return new Promise((resolve, reject) => {
-    this.query(query, options, (err, data) => {
+    this.query(query, options, function(err, data) {
       if (err) {
         reject(err);
       } else {

--- a/lib/queryPromise.js
+++ b/lib/queryPromise.js
@@ -1,8 +1,8 @@
 var Redshift = require('./connection.js');
 
 Redshift.prototype.queryPromise = function (query, options) {
-  return new Promise((resolve, reject) => {
-    this.query(query, options, function(err, data) {
+  return new Promise(function (resolve, reject) {
+    this.query(query, options, function (err, data) {
       if (err) {
         reject(err);
       } else {

--- a/lib/queryPromise.js
+++ b/lib/queryPromise.js
@@ -1,0 +1,13 @@
+var Redshift = require('./connection.js');
+
+Redshift.prototype.queryPromise = function (query, options) {
+  return new Promise((resolve, reject) => {
+    this.query(query, options, (err, data) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(data);
+      }
+    })
+  })
+};


### PR DESCRIPTION
I was using the library and added this prototype method so that I could create a Promise.all() array for multiple queries. Figured it would be useful for others too.